### PR TITLE
Patient History logo image to "scale-to-fit" with 2cm height.

### DIFF
--- a/api/src/main/resources/patientHistoryFopStylesheet.xsl
+++ b/api/src/main/resources/patientHistoryFopStylesheet.xsl
@@ -25,7 +25,7 @@
 									<fo:table-row>
 										<fo:table-cell>
 											<fo:block>
-												<fo:external-graphic height="1cm" src="{$logoImage}"/>
+												<fo:external-graphic height="2cm" content-height="scale-to-fit" src="{$logoImage}"/>
 											</fo:block>
 										</fo:table-cell>
 										<fo:table-cell>


### PR DESCRIPTION
This causes fixed resolution header images to be scaled to 2cm height (+- some FOP padding) in the header.