### PR TITLE
Patient History to handle obs groups.

### DIFF
--- a/api/src/main/java/org/openmrs/module/commonreports/data/converter/ObsGroupFromIdConvertor.java
+++ b/api/src/main/java/org/openmrs/module/commonreports/data/converter/ObsGroupFromIdConvertor.java
@@ -1,37 +1,31 @@
 package org.openmrs.module.commonreports.data.converter;
 
-import org.openmrs.Concept;
 import org.openmrs.Obs;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.reporting.data.converter.DataConverter;
 
-/**
- * Converts a Concept id to Concept data type
- */
-public class ConceptDataTypeConverter implements DataConverter {
-	
-	public ConceptDataTypeConverter() {
-	}
+public class ObsGroupFromIdConvertor implements DataConverter {
 	
 	@Override
 	public Object convert(Object original) {
 		Obs o = Context.getObsService().getObs((Integer) original);
-		
-		if (o.hasGroupMembers()) {
-			return "Group";
+		if (o != null && o.getObsGroup() != null) {
+			return o.getObsGroup().getId();
 		}
 		
-		Concept c = o.getConcept();
-		return c.getDatatype().getName();
+		return null;
 	}
 	
 	@Override
 	public Class<?> getInputDataType() {
-		return Integer.class;
+		// TODO Auto-generated method stub
+		return null;
 	}
 	
 	@Override
 	public Class<?> getDataType() {
-		return Object.class;
+		// TODO Auto-generated method stub
+		return null;
 	}
+	
 }

--- a/api/src/main/java/org/openmrs/module/commonreports/data/converter/ObsValueFromIdConverter.java
+++ b/api/src/main/java/org/openmrs/module/commonreports/data/converter/ObsValueFromIdConverter.java
@@ -1,5 +1,6 @@
 package org.openmrs.module.commonreports.data.converter;
 
+import org.openmrs.ConceptDatatype;
 import org.openmrs.Obs;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.reporting.common.ObjectUtil;
@@ -15,37 +16,39 @@ public class ObsValueFromIdConverter implements DataConverter {
 	
 	@Override
 	public Object convert(Object original) {
-		Obs o = (Obs) Context.getObsService().getObs((Integer) original);
+		Obs o = Context.getObsService().getObs((Integer) original);
 		if (o == null) {
 			return null;
 		}
-		if (o.getValueBoolean() != null) {
-			return o.getValueBoolean();
+		
+		if (o.hasGroupMembers()) {
+			return "";
 		}
-		if (o.getValueCoded() != null) {
-			return ObjectUtil.format(o.getValueCoded());
-		}
-		if (o.getValueComplex() != null) {
-			return o.getValueComplex();
-		}
-		if (o.getValueDatetime() != null) {
-			return o.getValueDatetime();
-		}
-		if (o.getValueDate() != null) {
-			return o.getValueDate();
-		}
+		
 		if (o.getValueDrug() != null) {
 			return ObjectUtil.format(o.getValueDrug());
 		}
-		if (o.getValueNumeric() != null) {
+		
+		ConceptDatatype dt = o.getConcept().getDatatype();
+		
+		if (dt.isBoolean()) {
+			return o.getValueBoolean();
+		} else if (dt.isCoded()) {
+			return ObjectUtil.format(o.getValueCoded());
+		} else if (dt.isComplex()) {
+			return o.getValueComplex();
+		} else if (dt.isDateTime()) {
+			return o.getValueDatetime();
+		} else if (dt.isDate()) {
+			return o.getValueDate();
+		} else if (dt.isNumeric()) {
 			return o.getValueNumeric();
-		}
-		if (o.getValueText() != null) {
+		} else if (dt.isText()) {
 			return o.getValueText();
-		}
-		if (o.getValueTime() != null) {
+		} else if (dt.isTime()) {
 			return o.getValueTime();
 		}
+		
 		return o.getValueAsString(Context.getLocale());
 	}
 	

--- a/api/src/main/java/org/openmrs/module/commonreports/renderer/PatientHistoryXmlReportRenderer.java
+++ b/api/src/main/java/org/openmrs/module/commonreports/renderer/PatientHistoryXmlReportRenderer.java
@@ -311,6 +311,8 @@ public class PatientHistoryXmlReportRenderer extends ReportDesignRenderer {
 				
 				String encounterUuid = row.getColumnValue(PatientHistoryReportManager.ENCOUNTER_UUID_LABEL).toString();
 				Element encounter = doc.getElementById(encounterUuid);
+				Element parent = encounter;
+				
 				if (encounter == null) {
 					// TODO: At least log this.
 				} else {
@@ -322,6 +324,13 @@ public class PatientHistoryXmlReportRenderer extends ReportDesignRenderer {
 						
 						switch (colName) {
 							case PatientHistoryReportManager.ENCOUNTER_UUID_LABEL:
+								break;
+							case PatientHistoryReportManager.OBS_GROUP_ID_LABEL:
+								
+								if (!StringUtils.isBlank(strValue)) {
+									parent = doc.getElementById(strValue);
+								}
+								
 								break;
 							case PatientHistoryReportManager.OBS_NAME_LABEL:
 								obs.setAttribute(ATTR_LABEL, strValue);
@@ -339,6 +348,8 @@ public class PatientHistoryXmlReportRenderer extends ReportDesignRenderer {
 								break;
 							case PatientHistoryReportManager.OBS_ID_LABEL:
 								obsId = strValue;
+								obs.setAttribute("id", strValue);
+								obs.setIdAttribute("id", true);
 								break;
 							case PatientHistoryReportManager.OBS_VALUE_LABEL:
 								if ("Complex".equals(type)) {
@@ -356,8 +367,9 @@ public class PatientHistoryXmlReportRenderer extends ReportDesignRenderer {
 						}
 					}
 					
-					encounter.appendChild(obs);
+					parent.appendChild(obs);
 				}
+				
 			}
 		}
 		

--- a/api/src/main/java/org/openmrs/module/commonreports/reports/PatientHistoryReportManager.java
+++ b/api/src/main/java/org/openmrs/module/commonreports/reports/PatientHistoryReportManager.java
@@ -16,6 +16,7 @@ import org.openmrs.module.commonreports.data.converter.ConceptDataTypeConverter;
 import org.openmrs.module.commonreports.data.converter.ConceptNameConverter;
 import org.openmrs.module.commonreports.data.converter.EncounterProviderFromIdConverter;
 import org.openmrs.module.commonreports.data.converter.EncounterTypeUUIDFromEncounterIdConverter;
+import org.openmrs.module.commonreports.data.converter.ObsGroupFromIdConvertor;
 import org.openmrs.module.commonreports.data.converter.ObsProviderFromIdConverter;
 import org.openmrs.module.commonreports.data.converter.ObsValueFromIdConverter;
 import org.openmrs.module.commonreports.data.converter.VisitLocationFromIdConverter;
@@ -85,6 +86,8 @@ public class PatientHistoryReportManager extends ActivatedReportManager {
 	public final static String OBS_PROVIDER_LABEL = "provider_name";
 	
 	public final static String OBS_ID_LABEL = "obs_id";
+	
+	public final static String OBS_GROUP_ID_LABEL = "obs_group_id";
 	
 	@Autowired
 	private EncounterDataLibrary encounterDataLibrary;
@@ -213,11 +216,13 @@ public class PatientHistoryReportManager extends ActivatedReportManager {
 		obsDataSetDef.addColumn(OBS_PROVIDER_LABEL, new ObsIdDataDefinition(), StringUtils.EMPTY,
 		    new ObsProviderFromIdConverter());
 		obsDataSetDef.addColumn(OBS_DATETIME_LABEL, new ObsDatetimeDataDefinition(), StringUtils.EMPTY, new DateConverter());
-		obsDataSetDef.addColumn(OBS_DATATYPE_LABEL, obsDataLibrary.getConceptId(), StringUtils.EMPTY,
-		    new ConceptDataTypeConverter());
+		obsDataSetDef.addColumn(OBS_DATATYPE_LABEL, /*obsDataLibrary.getConceptId()*/new ObsIdDataDefinition(),
+		    StringUtils.EMPTY, new ConceptDataTypeConverter());
 		obsDataSetDef.addColumn(OBS_NAME_LABEL, obsDataLibrary.getConceptId(), StringUtils.EMPTY,
 		    new ConceptNameConverter());
 		obsDataSetDef.addColumn(OBS_ID_LABEL, new ObsIdDataDefinition(), null, null);
+		obsDataSetDef.addColumn(OBS_GROUP_ID_LABEL, new ObsIdDataDefinition(), StringUtils.EMPTY,
+		    new ObsGroupFromIdConvertor());
 		obsDataSetDef.addColumn(OBS_VALUE_LABEL, new ObsIdDataDefinition(), StringUtils.EMPTY,
 		    new ObsValueFromIdConverter());
 		obsDataSetDef.addSortCriteria(OBS_DATETIME_LABEL, SortCriteria.SortDirection.DESC);

--- a/api/src/main/resources/patientHistoryFopStylesheet.xsl
+++ b/api/src/main/resources/patientHistoryFopStylesheet.xsl
@@ -117,7 +117,15 @@
 				<!-- filter out the obs that shouldnt go in a table while selecting to a new template,
 				this allows calling position() and getting the expected 1 and mod 1 -->
 					<!-- put text and coded, et c in table -->
-					<xsl:apply-templates select="obs[@type!='Image']" mode="table"/>
+					<xsl:apply-templates select="obs[@type!='Image' and @type!='Group']" mode="table"/>
+					<xsl:for-each select="obs[@type='Group']">
+						<fo:block border="solid 1pt black" margin="0.25cm" padding="0.25cm">
+							<fo:block font-style="italic">
+								<xsl:value-of select="@label"/>
+							</fo:block>
+							<xsl:apply-templates select="./obs" mode="table"/>
+						</fo:block>
+					</xsl:for-each>
 				</xsl:when>
 				<!-- otherwise put text obs on it's own line (e.g. long free text messages, if they're all the encounter has) -->
 				<xsl:otherwise>
@@ -175,7 +183,7 @@
 		<fo:table-row page-break-inside="avoid">
 		<!-- filter those obs that are handled by other formatting, @type!='Text' and @type!='Image' -->
       <!-- We select the current obs and add the following ones whose position doesn't exceed the row's width -->
-      <xsl:apply-templates select=".|following-sibling::obs[position() &lt; ($numColumns + 0)]" mode="cell"/>
+      <xsl:apply-templates select=".|following-sibling::obs[position() &lt; ($numColumns + 0) and @type!='Image' and @type!='Group']" mode="cell"/>
     </fo:table-row>
 	</xsl:template>	
     

--- a/api/src/test/resources/org/openmrs/module/commonreports/include/patientHistoryManagerTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/commonreports/include/patientHistoryManagerTestDataset.xml
@@ -7,6 +7,11 @@
 		creator="1" date_created="2006-01-18 00:00:00.0" voided="false"
 		uuid="5c87c4c1-7ecc-4f52-b5d4-5909d061f4e0" />
 
+	<person person_id="101" gender="F"
+		birthdate="1976-08-25 00:00:00.0" birthdate_estimated="1" dead="false"
+		creator="1" date_created="2006-01-18 00:00:00.0" voided="false"
+		uuid="a1d7bc22-10c7-4a87-ad51-0d567c9e7bd2" />
+
 	<person_address person_address_id="100" person_id="100"
 		preferred="false" address1="" address2="" city_village="Kapina"
 		state_province="" postal_code="" country="" latitude="" longitude=""
@@ -33,6 +38,10 @@
 		uuid="3abebf16-b827-4ac8-bc05-48d19b5be442" />
 
 	<patient patient_id="100" creator="1"
+		date_created="2006-01-18 00:00:00.0" changed_by="1"
+		date_changed="2008-08-18 12:25:57.0" voided="false" void_reason="" />
+
+	<patient patient_id="101" creator="1"
 		date_created="2006-01-18 00:00:00.0" changed_by="1"
 		date_changed="2008-08-18 12:25:57.0" voided="false" void_reason="" />
 
@@ -65,7 +74,19 @@
 		date_created="2004-08-12 00:00:00.0" version="0.1" changed_by="1"
 		date_changed="2006-06-09 14:57:33.0"
 		uuid="2347BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" />
-
+	
+	<concept concept_id="100004" retired="false" datatype_id="1"
+		class_id="5" is_set="false" creator="1"
+		date_created="2004-08-12 00:00:00.0" version="0.1" changed_by="1"
+		date_changed="2006-06-09 14:57:33.0"
+		uuid="f1d7fc32-a2ed-471a-9bd2-956e64d61c64" />
+	
+	<concept concept_id="100005" retired="false" datatype_id="3"
+		class_id="11" is_set="false" creator="1"
+		date_created="2004-08-12 00:00:00.0" version="0.1" changed_by="1"
+		date_changed="2006-06-09 14:57:33.0"
+		uuid="2ea9907f-7b0b-40b5-91e6-a381639becc9" />
+	
 	<concept_name concept_id="100000" name="Height (cm)"
 		locale="en" creator="1" date_created="2008-08-18 12:38:58.0"
 		concept_name_id="100000" voided="false"
@@ -86,6 +107,16 @@
 		concept_name_id="100003" voided="false"
 		uuid="2347BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" locale_preferred="true" />
 
+	<concept_name concept_id="100004" name="Arbitrary Concept used for Obs Group" locale="en"
+		creator="1" date_created="2008-08-18 12:38:58.0"
+		concept_name_id="100004" voided="false"
+		uuid="98076170-8605-4ba1-aa2f-2ef250d0c7fa" locale_preferred="true" />
+		
+	<concept_name concept_id="100005" name="Concept used for Obs Group child" locale="en"
+		creator="1" date_created="2008-08-18 12:38:58.0"
+		concept_name_id="100005" voided="false"
+		uuid="38455541-d7a4-4607-bbbd-90ff45a2dfa7" locale_preferred="true" />
+
 	<visit visit_id="100" patient_id="100" visit_type_id="3"
 		date_started="2019-01-01 00:00:00.0" location_id="1" creator="1"
 		date_created="2019-01-01 00:00:00.0" voided="0"
@@ -96,11 +127,22 @@
 		date_created="2019-01-01 00:00:00.0" retired="false"
 		uuid="b61ae905-664a-40f4-a638-a8f58ae03753" />
 
+	<encounter_type encounter_type_id="101" name="ObsGroup"
+		description="For demonstrating obs groups" creator="1"
+		date_created="2019-01-01 00:00:00.0" retired="false"
+		uuid="2cc138ca-735a-4f5c-8240-a7697983ef66" />
+
 	<encounter encounter_id="100" encounter_type="100"
 		patient_id="100" location_id="1" form_id="2"
 		encounter_datetime="2019-01-01 00:00:00.0" creator="1"
 		date_created="2019-01-01 14:09:05.0" voided="false" void_reason=""
 		uuid="53acc256-a393-42f2-a32c-b45dae4efd25" />
+
+	<encounter encounter_id="101" encounter_type="101"
+		patient_id="101" location_id="1" form_id="2"
+		encounter_datetime="2019-01-01 00:00:00.0" creator="1"
+		date_created="2019-01-01 14:09:05.0" voided="false" void_reason=""
+		uuid="fdcb05e9-7e51-41c1-9912-b21d19685767" />
 
 	<encounter_provider encounter_provider_id="100"
 		encounter_id="100" provider_id="2" encounter_role_id="1" creator="1"
@@ -136,5 +178,18 @@
 		location_id="1" value_numeric="60.0" comments="" creator="1"
 		date_created="2009-09-19 12:35:30.0" voided="false"
 		uuid="3b266e1b-1e08-4564-9ee1-6dae0e208ecb" />
+		
+	<obs obs_id="105" person_id="101" concept_id="100004"
+		encounter_id="101" obs_datetime="2019-01-01 00:00:00.0"
+		location_id="1" value_text="parent" comments="" creator="1"
+		date_created="2009-09-19 12:35:30.0" voided="false"
+		uuid="15134ab3-9167-47f6-b6e8-d58220c4389c" />
 
+	<obs obs_id="106" person_id="101" concept_id="100005"
+		encounter_id="101" obs_datetime="2019-01-01 00:00:00.0"
+		location_id="1" value_text="child" comments="" creator="1"
+		obs_group_id="105"
+		date_created="2009-09-19 12:35:30.0" voided="false"
+		uuid="6d377cea-1f76-4369-b2f1-f2eff2b0a383" />
+		
 </dataset>


### PR DESCRIPTION
 * adding converter and column for obs group
 * modifying value converter for groups and by type instead of by ordered non-null value conditions
 * adding xml renderer id attribute and making group member obs xml children of parent obs
 * adding xsl updates to render obs groups in their own boxed table with grouping obs label as title

 * adds a simple obs group unit test case in API (verifies input XML, does not verify PDF byte [])

 * should also resolve #17 

@mks-d 