### PR TITLE
Spring web application context to not scan commonreports.web.controller anymore.

### DIFF
--- a/omod/src/main/resources/webModuleApplicationContext.xml
+++ b/omod/src/main/resources/webModuleApplicationContext.xml
@@ -20,5 +20,4 @@
   		    http://www.springframework.org/schema/util
   		    http://www.springframework.org/schema/util/spring-util-3.0.xsd">
 
-	<context:component-scan base-package="org.openmrs.module.commonreports.web.controller" />
 </beans>


### PR DESCRIPTION
The definition of the bean is not needed here as it is already defined. This can cause issues and can be the source of some tricky-to-fix bugs.